### PR TITLE
Use double quotes on command execution

### DIFF
--- a/lib/lobster/job.rb
+++ b/lib/lobster/job.rb
@@ -59,7 +59,7 @@ module Lobster
       create_pipes
 
       Lobster.logger.info "Starting job #{@name}"
-      command_line = @user ? "sudo -nu #{@user} -- sh -lc 'cd #{@directory}; #{@command}'" : @command
+      command_line = @user ? "sudo -nu #{@user} -- sh -lc \"cd #{@directory}; #{@command}\"" : @command
 
       begin
         @pid = spawn(command_line, :out=>@wout, :err=>@werr, :chdir=> @directory)


### PR DESCRIPTION
- This enables the use of single quote for string arguments
- Was a problem for us as we use hadoop glob patterns for a specific job

Change-Id: I1b85f9fb2d224548fef09d9724c0c6c683ca7553